### PR TITLE
Linter 130s timeout and primitive logging

### DIFF
--- a/linter/src/config.h.in
+++ b/linter/src/config.h.in
@@ -24,6 +24,9 @@
 
 #define FIREBASE_URL "https://nutc-web-default-rtdb.firebaseio.com/"
 
+// Linting
+#define LINT_AUTO_TIMEOUT_SECONDS 120
+#define LINT_ABSOLUTE_TIMEOUT_SECONDS 130
 
 /**
  * If we are in debug mode.

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -31,26 +31,6 @@ get_server_thread()
 
             spawning::spawn_client(uid, algo_id, pid);
 
-            // After 130 seconds, check status - if still pending, set failure and stop
-            std::this_thread::sleep_for(std::chrono::seconds(130));
-
-            // Check status from Firebase
-            std::optional<std::string> linting_status =
-                nutc::client::get_algo_status(uid, algo_id);
-
-            // If status is pending, force push a failure
-            if (linting_status.has_value()) {
-                if (linting_status == "pending") {
-                    // Push failure
-                    std::string error_msg =
-                        "unknown runtime error: your code is syntactically correct but "
-                        "crashed during runtime";
-
-                    nutc::client::set_lint_result(uid, algo_id, false);
-                    nutc::client::set_lint_failure(uid, algo_id, error_msg);
-                }
-            }
-
             return crow::response();
         });
         app.port(8080).run();

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -1,5 +1,7 @@
 #include "crow.hpp"
 
+#include "firebase/fetching.hpp"
+
 namespace nutc {
 namespace crow {
 
@@ -23,6 +25,40 @@ get_server_thread()
             }
             std::string uid = req.url_params.get("uid");
             std::string algo_id = req.url_params.get("algo_id");
+
+            // Watchdog to check for crash/pending after 130s
+            std::thread check_pending_thread([&algo_id = algo_id, &uid = uid]() {
+                std::this_thread::sleep_for(std::chrono::seconds(130));
+
+                // Check status from Firebase
+                nutc::client::LINTING_RESULT_OPTIONS linting_status =
+                    nutc::client::get_algo_status(uid, algo_id);
+
+                // If status is pending, force push a failure
+                if (linting_status
+                    == nutc::client::LINTING_RESULT_OPTIONS::LRO_PENDING) {
+                    // TODO: include branches for LRO_UNKNOWN (?)
+                    // Push failure
+                    std::string error_msg =
+                        "unknown runtime error: your code is syntactically correct but "
+                        "timed out (130 seconds) while linting";
+
+                    nutc::client::set_lint_result(uid, algo_id, false);
+                    nutc::client::set_lint_failure(uid, algo_id, error_msg);
+                }
+
+                log_e(
+                    main,
+                    "Algoid {} for uid {} still pending after 130s. FORCE PUSHING "
+                    "failure to "
+                    "Firebase.",
+                    algo_id,
+                    uid
+                );
+
+                std::exit(1);
+            });
+            check_pending_thread.detach();
 
             spawning::spawn_client(uid, algo_id);
 

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -1,5 +1,7 @@
 #include "crow.hpp"
 
+#include "firebase/fetching.hpp"
+
 namespace nutc {
 namespace crow {
 
@@ -28,6 +30,7 @@ get_server_thread()
             spawning::spawn_client(uid, algo_id, pid);
 
             // After 130 seconds, check status - if still pending, set failure and stop
+            int status = 0;
             std::this_thread::sleep_for(std::chrono::seconds(130));
             pid_t result = waitpid(pid, &status, WNOHANG);
 

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -2,6 +2,8 @@
 
 #include "firebase/fetching.hpp"
 
+#include <sys/wait.h>
+
 namespace nutc {
 namespace crow {
 

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -23,10 +23,30 @@ get_server_thread()
             }
             std::string uid = req.url_params.get("uid");
             std::string algo_id = req.url_params.get("algo_id");
+            pid_t pid = fork();
 
-            spawning::spawn_client(uid, algo_id);
+            spawning::spawn_client(uid, algo_id, pid);
 
-            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+            // After 130 seconds, check status - if still pending, set failure and stop
+            std::this_thread::sleep_for(std::chrono::seconds(130));
+            pid_t result = waitpid(pid, &status, WNOHANG);
+
+            // Some flags
+            bool should_kill = false;  // If should force kill PID
+            bool push_failure = false; // If should tell Firebase
+
+            if (should_kill) {
+                // Kill process PID
+                kill(pid, SIGKILL);
+            }
+
+            if (push_failure) {
+                // Push failure to Firebase
+                nutc::client::set_lint_failure(
+                    uid, algo_id, "Linting not completed after 130 seconds.\n"
+                ); // TODO: pass ss str back from the process to have better error msg
+            }
+
             return crow::response();
         });
         app.port(8080).run();

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -1,9 +1,5 @@
 #include "crow.hpp"
 
-#include "firebase/fetching.hpp"
-
-#include <sys/wait.h>
-
 namespace nutc {
 namespace crow {
 

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -32,15 +32,12 @@ get_server_thread()
             pid_t result = waitpid(pid, &status, WNOHANG);
 
             // Some flags
-            bool should_kill = false;  // If should force kill PID
-            bool push_failure = false; // If should tell Firebase
-
-            if (should_kill) {
-                // Kill process PID
-                kill(pid, SIGKILL);
-            }
+            bool push_failure = (WIFEXITED(status) && WEXITSTATUS(status) != 0);
 
             if (push_failure) {
+                // Kill process
+                kill(pid, SIGKILL);
+
                 // Push failure to Firebase
                 nutc::client::set_lint_failure(
                     uid, algo_id, "Linting not completed after 130 seconds.\n"

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -27,7 +27,8 @@ get_server_thread()
             std::string uid = req.url_params.get("uid");
             std::string algo_id = req.url_params.get("algo_id");
 
-            // Watchdog to check for crash/pending after 130s
+            // Watchdog to check for crash/pending after
+            // LINT_ABSOLUTE_TIMEOUT_SECONDS seconds (default 130s)
             std::thread check_pending_thread([&algo_id = algo_id, &uid = uid]() {
                 std::this_thread::sleep_for(
                     std::chrono::seconds(LINT_ABSOLUTE_TIMEOUT_SECONDS)

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -27,9 +27,8 @@ get_server_thread()
             }
             std::string uid = req.url_params.get("uid");
             std::string algo_id = req.url_params.get("algo_id");
-            pid_t pid = fork();
 
-            spawning::spawn_client(uid, algo_id, pid);
+            spawning::spawn_client(uid, algo_id);
 
             return crow::response();
         });

--- a/linter/src/crow/crow.cpp
+++ b/linter/src/crow/crow.cpp
@@ -31,13 +31,11 @@ get_server_thread()
                 std::this_thread::sleep_for(std::chrono::seconds(130));
 
                 // Check status from Firebase
-                nutc::client::LINTING_RESULT_OPTIONS linting_status =
+                nutc::client::LintingResultOption linting_status =
                     nutc::client::get_algo_status(uid, algo_id);
 
                 // If status is pending, force push a failure
-                if (linting_status
-                    == nutc::client::LINTING_RESULT_OPTIONS::LRO_PENDING) {
-                    // TODO: include branches for LRO_UNKNOWN (?)
+                if (linting_status == nutc::client::LintingResultOption::PENDING) {
                     // Push failure
                     std::string error_msg =
                         "unknown runtime error: your code is syntactically correct but "
@@ -45,16 +43,26 @@ get_server_thread()
 
                     nutc::client::set_lint_result(uid, algo_id, false);
                     nutc::client::set_lint_failure(uid, algo_id, error_msg);
+
+                    log_e(
+                        main,
+                        "Algoid {} for uid {} still pending after 130s. FORCE PUSHING "
+                        "failure to "
+                        "Firebase.",
+                        algo_id,
+                        uid
+                    );
                 }
 
-                log_e(
-                    main,
-                    "Algoid {} for uid {} still pending after 130s. FORCE PUSHING "
-                    "failure to "
-                    "Firebase.",
-                    algo_id,
-                    uid
-                );
+                if (linting_status == nutc::client::LintingResultOption::UNKNOWN) {
+                    // can add a push to firebase here
+                    log_e(
+                        main,
+                        "Algoid {} for uid {} unknown status after 130s.",
+                        algo_id,
+                        uid
+                    );
+                }
 
                 std::exit(1);
             });

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -148,6 +148,26 @@ get_algo(const std::string& uid, const std::string& algo_id)
     return algo_file;
 }
 
+std::optional<std::string>
+get_algo_status(const std::string& uid, const std::string& algo_id)
+{
+    glz::json_t user_info = get_user_info(uid);
+    // if not has "algos"
+    if (!user_info.contains("algos")) {
+        log_w(
+            firebase, "User {} has no algos. Will not participate in simulation.", uid
+        );
+        return std::nullopt;
+    }
+    if (!user_info["algos"].contains(algo_id)) {
+        log_w(firebase, "User {} does not have algo id {}.", uid, algo_id);
+        return std::nullopt;
+    }
+    glz::json_t algo_info = user_info["algos"][algo_id];
+    std::string linting_result = algo_info["lintResults"].get<std::string>();
+    return linting_result;
+}
+
 glz::json_t
 firebase_request(
     const std::string& method, const std::string& url, const std::string& data

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -148,7 +148,7 @@ get_algo(const std::string& uid, const std::string& algo_id)
     return algo_file;
 }
 
-std::optional<std::string>
+int
 get_algo_status(const std::string& uid, const std::string& algo_id)
 {
     glz::json_t user_info = get_user_info(uid);
@@ -157,15 +157,24 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
         log_w(
             firebase, "User {} has no algos. Will not participate in simulation.", uid
         );
-        return std::nullopt;
+        return nutc::client::LRO_UNKNOWN;
     }
     if (!user_info["algos"].contains(algo_id)) {
         log_w(firebase, "User {} does not have algo id {}.", uid, algo_id);
-        return std::nullopt;
+        return nutc::client::LRO_UNKNOWN;
     }
     glz::json_t algo_info = user_info["algos"][algo_id];
     std::string linting_result = algo_info["lintResults"].get<std::string>();
-    return linting_result;
+
+    if (linting_result == "failure") {
+        return nutc::client::LRO_FAILURE;
+    }
+    else if (linting_result == "success") {
+        return nutc::client::LRO_SUCCESS;
+    }
+    else {
+        return nutc::client::LRO_PENDING;
+    }
 }
 
 glz::json_t

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -170,7 +170,10 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
     // check if this algo id has lint results
     if (!algo_info.contains("lintResults")) {
         log_w(
-            firebase, "User {} algoid {} has no lint result, assuming unknown.", uid, algo_id
+            firebase,
+            "User {} algoid {} has no lint result, assuming unknown.",
+            uid,
+            algo_id
         );
         return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
     }

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -148,7 +148,7 @@ get_algo(const std::string& uid, const std::string& algo_id)
     return algo_file;
 }
 
-int
+nutc::client::LINTING_RESULT_OPTIONS
 get_algo_status(const std::string& uid, const std::string& algo_id)
 {
     glz::json_t user_info = get_user_info(uid);
@@ -157,34 +157,34 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
         log_w(
             firebase, "User {} has no algos. Will not participate in simulation.", uid
         );
-        return nutc::client::LRO_UNKNOWN;
+        return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
     }
 
     // check if algo id exists
     if (!user_info["algos"].contains(algo_id)) {
         log_w(firebase, "User {} does not have algo id {}.", uid, algo_id);
-        return nutc::client::LRO_UNKNOWN;
+        return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
     }
     glz::json_t algo_info = user_info["algos"][algo_id];
 
     // check if this algo id has lint results
     if (!algo_info.contains("lintResults")) {
         log_w(
-            firebase, "User {} algoid {} has no lint result, assuming unknown.", uid
+            firebase, "User {} algoid {} has no lint result, assuming unknown.", uid, algo_id
         );
-        return nutc::client::LRO_UNKNOWN;
+        return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
     }
 
     std::string linting_result = algo_info["lintResults"].get<std::string>();
 
     if (linting_result == "failure") {
-        return nutc::client::LRO_FAILURE;
+        return nutc::client::LINTING_RESULT_OPTIONS::LRO_FAILURE;
     }
     else if (linting_result == "success") {
-        return nutc::client::LRO_SUCCESS;
+        return nutc::client::LINTING_RESULT_OPTIONS::LRO_SUCCESS;
     }
     else {
-        return nutc::client::LRO_PENDING;
+        return nutc::client::LINTING_RESULT_OPTIONS::LRO_PENDING;
     }
 }
 

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -159,11 +159,22 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
         );
         return nutc::client::LRO_UNKNOWN;
     }
+
+    // check if algo id exists
     if (!user_info["algos"].contains(algo_id)) {
         log_w(firebase, "User {} does not have algo id {}.", uid, algo_id);
         return nutc::client::LRO_UNKNOWN;
     }
     glz::json_t algo_info = user_info["algos"][algo_id];
+
+    // check if this algo id has lint results
+    if (!algo_info.contains("lintResults")) {
+        log_w(
+            firebase, "User {} algoid {} has no lint result, assuming unknown.", uid
+        );
+        return nutc::client::LRO_UNKNOWN;
+    }
+
     std::string linting_result = algo_info["lintResults"].get<std::string>();
 
     if (linting_result == "failure") {

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -148,7 +148,7 @@ get_algo(const std::string& uid, const std::string& algo_id)
     return algo_file;
 }
 
-nutc::client::LINTING_RESULT_OPTIONS
+nutc::client::LintingResultOption
 get_algo_status(const std::string& uid, const std::string& algo_id)
 {
     glz::json_t user_info = get_user_info(uid);
@@ -157,13 +157,13 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
         log_w(
             firebase, "User {} has no algos. Will not participate in simulation.", uid
         );
-        return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
+        return nutc::client::LintingResultOption::UNKNOWN;
     }
 
     // check if algo id exists
     if (!user_info["algos"].contains(algo_id)) {
         log_w(firebase, "User {} does not have algo id {}.", uid, algo_id);
-        return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
+        return nutc::client::LintingResultOption::UNKNOWN;
     }
     glz::json_t algo_info = user_info["algos"][algo_id];
 
@@ -175,19 +175,19 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
             uid,
             algo_id
         );
-        return nutc::client::LINTING_RESULT_OPTIONS::LRO_UNKNOWN;
+        return nutc::client::LintingResultOption::UNKNOWN;
     }
 
     std::string linting_result = algo_info["lintResults"].get<std::string>();
 
     if (linting_result == "failure") {
-        return nutc::client::LINTING_RESULT_OPTIONS::LRO_FAILURE;
+        return nutc::client::LintingResultOption::FAILURE;
     }
     else if (linting_result == "success") {
-        return nutc::client::LINTING_RESULT_OPTIONS::LRO_SUCCESS;
+        return nutc::client::LintingResultOption::SUCCESS;
     }
     else {
-        return nutc::client::LINTING_RESULT_OPTIONS::LRO_PENDING;
+        return nutc::client::LintingResultOption::PENDING;
     }
 }
 

--- a/linter/src/firebase/fetching.cpp
+++ b/linter/src/firebase/fetching.cpp
@@ -180,14 +180,13 @@ get_algo_status(const std::string& uid, const std::string& algo_id)
 
     std::string linting_result = algo_info["lintResults"].get<std::string>();
 
-    if (linting_result == "failure") {
-        return nutc::client::LintingResultOption::FAILURE;
-    }
-    else if (linting_result == "success") {
-        return nutc::client::LintingResultOption::SUCCESS;
-    }
-    else {
-        return nutc::client::LintingResultOption::PENDING;
+    switch (linting_result[0]) {
+        case 'f':
+            return nutc::client::LintingResultOption::FAILURE;
+        case 's':
+            return nutc::client::LintingResultOption::SUCCESS;
+        default:
+            return nutc::client::LintingResultOption::PENDING;
     }
 }
 

--- a/linter/src/firebase/fetching.hpp
+++ b/linter/src/firebase/fetching.hpp
@@ -15,7 +15,12 @@
 namespace nutc {
 namespace client {
 
-enum LINTING_RESULT_OPTIONS { LRO_UNKNOWN = -1, LRO_FAILURE, LRO_SUCCESS, LRO_PENDING };
+enum class LINTING_RESULT_OPTIONS { 
+    LRO_UNKNOWN = -1, 
+    LRO_FAILURE, 
+    LRO_SUCCESS, 
+    LRO_PENDING 
+};
 
 // database request - change name
 glz::json_t firebase_request(
@@ -36,7 +41,7 @@ void set_lint_success(
 );
 
 std::optional<std::string> get_algo(const std::string& uid, const std::string& algo_id);
-int get_algo_status(
+LINTING_RESULT_OPTIONS get_algo_status(
     const std::string& uid, const std::string& algo_id
 ); // returns a LINTING_RESULT_OPTIONS enum
 

--- a/linter/src/firebase/fetching.hpp
+++ b/linter/src/firebase/fetching.hpp
@@ -34,6 +34,9 @@ void set_lint_success(
 );
 
 std::optional<std::string> get_algo(const std::string& uid, const std::string& algo_id);
+std::optional<std::string> get_algo_status(
+    const std::string& uid, const std::string& algo_id
+); // failure, pending, success
 
 } // namespace client
 } // namespace nutc

--- a/linter/src/firebase/fetching.hpp
+++ b/linter/src/firebase/fetching.hpp
@@ -15,12 +15,7 @@
 namespace nutc {
 namespace client {
 
-enum class LINTING_RESULT_OPTIONS {
-    LRO_UNKNOWN = -1,
-    LRO_FAILURE,
-    LRO_SUCCESS,
-    LRO_PENDING
-};
+enum class LintingResultOption { UNKNOWN = -1, FAILURE, SUCCESS, PENDING };
 
 // database request - change name
 glz::json_t firebase_request(
@@ -41,9 +36,9 @@ void set_lint_success(
 );
 
 std::optional<std::string> get_algo(const std::string& uid, const std::string& algo_id);
-LINTING_RESULT_OPTIONS get_algo_status(
+LintingResultOption get_algo_status(
     const std::string& uid, const std::string& algo_id
-); // returns a LINTING_RESULT_OPTIONS enum
+); // returns a LintingResultOption enum
 
 } // namespace client
 } // namespace nutc

--- a/linter/src/firebase/fetching.hpp
+++ b/linter/src/firebase/fetching.hpp
@@ -15,11 +15,11 @@
 namespace nutc {
 namespace client {
 
-enum class LINTING_RESULT_OPTIONS { 
-    LRO_UNKNOWN = -1, 
-    LRO_FAILURE, 
-    LRO_SUCCESS, 
-    LRO_PENDING 
+enum class LINTING_RESULT_OPTIONS {
+    LRO_UNKNOWN = -1,
+    LRO_FAILURE,
+    LRO_SUCCESS,
+    LRO_PENDING
 };
 
 // database request - change name

--- a/linter/src/firebase/fetching.hpp
+++ b/linter/src/firebase/fetching.hpp
@@ -15,6 +15,8 @@
 namespace nutc {
 namespace client {
 
+enum LINTING_RESULT_OPTIONS { LRO_UNKNOWN = -1, LRO_FAILURE, LRO_SUCCESS, LRO_PENDING };
+
 // database request - change name
 glz::json_t firebase_request(
     const std::string& method, const std::string& url, const std::string& data = ""
@@ -34,9 +36,9 @@ void set_lint_success(
 );
 
 std::optional<std::string> get_algo(const std::string& uid, const std::string& algo_id);
-std::optional<std::string> get_algo_status(
+int get_algo_status(
     const std::string& uid, const std::string& algo_id
-); // failure, pending, success
+); // returns a LINTING_RESULT_OPTIONS enum
 
 } // namespace client
 } // namespace nutc

--- a/linter/src/lint/lint.cpp
+++ b/linter/src/lint/lint.cpp
@@ -3,18 +3,21 @@
 namespace nutc {
 namespace lint {
 std::string
-lint(const std::string& uid, const std::string& algo_id, std::string& output_stream)
+lint(
+    const std::string& uid, const std::string& algo_id, std::stringstream& output_stream
+)
 {
     std::optional<std::string> algoCode = nutc::client::get_algo(uid, algo_id);
     if (!algoCode.has_value()) {
-        output_stream << "[linter] FAILURE - could not find algo id " << algoid << " for uid " << uid << "\n"
+        output_stream << "[linter] FAILURE - could not find algo id " << algo_id
+                      << " for uid " << uid << "\n";
         return "Could not find algorithm";
     }
 
     bool e = nutc::pywrapper::create_api_module(nutc::mock_api::getMarketFunc());
     if (!e) {
         log_e(linting, "Failed to create API module");
-        output_stream << "[linter] failed to create API module\n"
+        output_stream << "[linter] failed to create API module\n";
         nutc::client::set_lint_result(uid, algo_id, false);
         return "Unexpected error: failed to create API module";
     }
@@ -22,7 +25,7 @@ lint(const std::string& uid, const std::string& algo_id, std::string& output_str
     std::optional<std::string> err = nutc::pywrapper::import_py_code(algoCode.value());
     if (err.has_value()) {
         log_e(linting, "{}", err.value());
-        output_stream << err.value() << "\n"
+        output_stream << err.value() << "\n";
         nutc::client::set_lint_result(uid, algo_id, false);
         nutc::client::set_lint_failure(uid, algo_id, err.value());
         return err.value();
@@ -31,7 +34,7 @@ lint(const std::string& uid, const std::string& algo_id, std::string& output_str
     err = nutc::pywrapper::run_initialization();
     if (err.has_value()) {
         log_e(linting, "{}", err.value());
-        output_stream << err.value() << "\n"
+        output_stream << err.value() << "\n";
         nutc::client::set_lint_result(uid, algo_id, false);
         nutc::client::set_lint_failure(uid, algo_id, err.value());
         return err.value();
@@ -40,7 +43,7 @@ lint(const std::string& uid, const std::string& algo_id, std::string& output_str
     err = nutc::pywrapper::trigger_callbacks();
     if (err.has_value()) {
         log_e(linting, "{}", err.value());
-        output_stream << err.value() << "\n"
+        output_stream << err.value() << "\n";
         nutc::client::set_lint_result(uid, algo_id, false);
         nutc::client::set_lint_failure(uid, algo_id, err.value());
         return err.value();
@@ -48,7 +51,9 @@ lint(const std::string& uid, const std::string& algo_id, std::string& output_str
 
     nutc::client::set_lint_result(uid, algo_id, true);
 
-    output_stream << "[linter] linting process done!" << "\n"
+    output_stream << "[linter] linting process done!"
+                  << "\n";
+
     return "Lint succeeded!";
 }
 } // namespace lint

--- a/linter/src/lint/lint.hpp
+++ b/linter/src/lint/lint.hpp
@@ -11,7 +11,7 @@
 namespace nutc {
 namespace lint {
 
-[[nodiscard]] std::string lint(const std::string& uid, const std::string& algo_id);
+[[nodiscard]] std::string lint(const std::string& uid, const std::string& algo_id, std::string& output_stream);
 
 } // namespace lint
 } // namespace nutc

--- a/linter/src/lint/lint.hpp
+++ b/linter/src/lint/lint.hpp
@@ -11,7 +11,9 @@
 namespace nutc {
 namespace lint {
 
-[[nodiscard]] std::string lint(const std::string& uid, const std::string& algo_id, std::string& output_stream);
+[[nodiscard]] std::string lint(
+    const std::string& uid, const std::string& algo_id, std::stringstream& output_stream
+);
 
 } // namespace lint
 } // namespace nutc

--- a/linter/src/spawner/main.cpp
+++ b/linter/src/spawner/main.cpp
@@ -85,7 +85,8 @@ main(int argc, const char** argv)
             algoid,
             uid
         );
-        ss << "[linter] FAILED to lint algo_id " << algoid << " for uid " << uid << "\n";
+        ss << "[linter] FAILED to lint algo_id " << algoid << " for uid " << uid
+           << "\n";
 
         nutc::client::set_lint_failure(uid, algoid, ss.str() + "Failure!\n");
         std::exit(1);
@@ -103,7 +104,8 @@ main(int argc, const char** argv)
     std::string response = nutc::lint::lint(uid, algoid, ss);
 
     log_i(main, "Finished linting algo_id: {} for user: {}", algoid, uid);
-    ss << "[linter] exited linting process and finished linting algo_id " << algoid << " for uid " << uid << "\n";
+    ss << "[linter] exited linting process and finished linting algo_id " << algoid
+       << " for uid " << uid << "\n";
 
     nutc::client::set_lint_success(uid, algoid, ss.str() + "Success!\n");
 

--- a/linter/src/spawner/main.cpp
+++ b/linter/src/spawner/main.cpp
@@ -98,20 +98,18 @@ main(int argc, const char** argv)
         std::this_thread::sleep_for(std::chrono::seconds(130));
 
         // Check status from Firebase
-        std::optional<std::string> linting_status =
-            nutc::client::get_algo_status(uid, algoid);
+        int linting_status = nutc::client::get_algo_status(uid, algoid);
 
         // If status is pending, force push a failure
-        if (linting_status.has_value()) {
-            if (linting_status == "pending") {
-                // Push failure
-                std::string error_msg =
-                    "unknown runtime error: your code is syntactically correct but "
-                    "crashed during runtime";
+        if (linting_status == nutc::client::LRO_PENDING) { // TODO: include branches for
+                                                           // LRO_UNKNOWN (?)
+            // Push failure
+            std::string error_msg =
+                "unknown runtime error: your code is syntactically correct but "
+                "timed out (130 seconds) while linting";
 
-                nutc::client::set_lint_result(uid, algoid, false);
-                nutc::client::set_lint_failure(uid, algoid, error_msg);
-            }
+            nutc::client::set_lint_result(uid, algoid, false);
+            nutc::client::set_lint_failure(uid, algoid, error_msg);
         }
 
         log_e(

--- a/linter/src/spawner/main.cpp
+++ b/linter/src/spawner/main.cpp
@@ -93,39 +93,6 @@ main(int argc, const char** argv)
     });
     timeout_thread.detach();
 
-    // Secondary watchdog to check for crash/pending after 130s
-    std::thread check_pending_thread([&ss = ss, &algoid = algoid, &uid = uid]() {
-        std::this_thread::sleep_for(std::chrono::seconds(130));
-
-        // Check status from Firebase
-        nutc::client::LINTING_RESULT_OPTIONS linting_status = nutc::client::get_algo_status(uid, algoid);
-
-        // If status is pending, force push a failure
-        if (linting_status == nutc::client::LINTING_RESULT_OPTIONS::LRO_PENDING) { // TODO: include branches for
-                                                           // LRO_UNKNOWN (?)
-            // Push failure
-            std::string error_msg =
-                "unknown runtime error: your code is syntactically correct but "
-                "timed out (130 seconds) while linting";
-
-            nutc::client::set_lint_result(uid, algoid, false);
-            nutc::client::set_lint_failure(uid, algoid, error_msg);
-        }
-
-        log_e(
-            main,
-            "Algoid {} for uid {} still pending after 130s. FORCE PUSHING failure to "
-            "Firebase.",
-            algoid,
-            uid
-        );
-        ss << "[linter] unknown runtime error for lint algo_id " << algoid
-           << " and uid " << uid << "\n";
-
-        std::exit(1);
-    });
-    check_pending_thread.detach();
-
     // Log this event
     log_i(main, "Linting algo_id: {} for user: {}", algoid, uid);
     ss << "[linter] starting to lint algo_id " << algoid << " for uid " << uid << "\n";

--- a/linter/src/spawner/main.cpp
+++ b/linter/src/spawner/main.cpp
@@ -99,7 +99,7 @@ main(int argc, const char** argv)
 
         // Check status from Firebase
         std::optional<std::string> linting_status =
-                nutc::client::get_algo_status(uid, algo_id);
+                nutc::client::get_algo_status(uid, algoid);
 
         // If status is pending, force push a failure
         if (linting_status.has_value()) {
@@ -109,8 +109,8 @@ main(int argc, const char** argv)
                     "unknown runtime error: your code is syntactically correct but "
                     "crashed during runtime";
 
-                nutc::client::set_lint_result(uid, algo_id, false);
-                nutc::client::set_lint_failure(uid, algo_id, error_msg);
+                nutc::client::set_lint_result(uid, algoid, false);
+                nutc::client::set_lint_failure(uid, algoid, error_msg);
             }
         }
 

--- a/linter/src/spawner/main.cpp
+++ b/linter/src/spawner/main.cpp
@@ -99,7 +99,7 @@ main(int argc, const char** argv)
 
         // Check status from Firebase
         std::optional<std::string> linting_status =
-                nutc::client::get_algo_status(uid, algoid);
+            nutc::client::get_algo_status(uid, algoid);
 
         // If status is pending, force push a failure
         if (linting_status.has_value()) {
@@ -116,12 +116,13 @@ main(int argc, const char** argv)
 
         log_e(
             main,
-            "Algoid {} for uid {} still pending after 130s. FORCE PUSHING failure to Firebase.",
+            "Algoid {} for uid {} still pending after 130s. FORCE PUSHING failure to "
+            "Firebase.",
             algoid,
             uid
         );
-        ss << "[linter] unknown runtime error for lint algo_id " << algoid << " and uid " << uid
-           << "\n";
+        ss << "[linter] unknown runtime error for lint algo_id " << algoid
+           << " and uid " << uid << "\n";
 
         std::exit(1);
     });

--- a/linter/src/spawner/main.cpp
+++ b/linter/src/spawner/main.cpp
@@ -98,10 +98,10 @@ main(int argc, const char** argv)
         std::this_thread::sleep_for(std::chrono::seconds(130));
 
         // Check status from Firebase
-        int linting_status = nutc::client::get_algo_status(uid, algoid);
+        nutc::client::LINTING_RESULT_OPTIONS linting_status = nutc::client::get_algo_status(uid, algoid);
 
         // If status is pending, force push a failure
-        if (linting_status == nutc::client::LRO_PENDING) { // TODO: include branches for
+        if (linting_status == nutc::client::LINTING_RESULT_OPTIONS::LRO_PENDING) { // TODO: include branches for
                                                            // LRO_UNKNOWN (?)
             // Push failure
             std::string error_msg =

--- a/linter/src/spawning/spawning.cpp
+++ b/linter/src/spawning/spawning.cpp
@@ -4,10 +4,10 @@ namespace nutc {
 namespace spawning {
 
 void
-spawn_client(const std::string& uid, std::string& algoid)
+spawn_client(const std::string& uid, std::string& algoid, pid_t& pid)
 {
     std::replace(algoid.begin(), algoid.end(), '-', ' ');
-    pid_t pid = fork();
+
     if (pid == 0) {
         std::vector<std::string> args = {
             "NUTC-linter-spawner", "--uid", uid, "--algoid", algoid

--- a/linter/src/spawning/spawning.cpp
+++ b/linter/src/spawning/spawning.cpp
@@ -4,9 +4,10 @@ namespace nutc {
 namespace spawning {
 
 void
-spawn_client(const std::string& uid, std::string& algoid, pid_t& pid)
+spawn_client(const std::string& uid, std::string& algoid)
 {
     std::replace(algoid.begin(), algoid.end(), '-', ' ');
+    pid_t pid = fork();
 
     if (pid == 0) {
         std::vector<std::string> args = {

--- a/linter/src/spawning/spawning.hpp
+++ b/linter/src/spawning/spawning.hpp
@@ -9,7 +9,7 @@
 namespace nutc {
 namespace spawning {
 
-void spawn_client(const std::string& uid, std::string& algoid);
+void spawn_client(const std::string& uid, std::string& algoid, pid_t& pid);
 
 }
 } // namespace nutc

--- a/linter/src/spawning/spawning.hpp
+++ b/linter/src/spawning/spawning.hpp
@@ -9,7 +9,7 @@
 namespace nutc {
 namespace spawning {
 
-void spawn_client(const std::string& uid, std::string& algoid, pid_t& pid);
+void spawn_client(const std::string& uid, std::string& algoid);
 
 }
 } // namespace nutc


### PR DESCRIPTION
Added 130s timeout. After 130s, if the process has not returned 0, force push a failure to Firebase. Moved some log_e and log_i to the ss stream which theoretically goes to Firebase too.

needs more testing lol