### PR TITLE
Add brownian motion stochastic random noise generator

### DIFF
--- a/exchange/CMakeLists.txt
+++ b/exchange/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(
     src/matching/engine/engine.cpp
     src/client_manager/client_manager.cpp
     src/utils/logger/logger.cpp
+    src/randomness/brownian.cpp
 )
 
 target_include_directories(

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -17,7 +17,14 @@ namespace brownian {
 float
 BrownianMotion::generate_next_price()
 {
+    float current_price = this->cur_value;
+    std::normal_distribution<double> distribution(-this->cur_value/1000, stddev);
+    
+    float delta_current_price = distribution(this->random_number_generator);
+    float new_price = current_price + delta_current_price;
 
+    this->cur_value = new_price;
+    return new_price;
 }
 
 }

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -4,9 +4,9 @@
  * @brief Brownian motion randomness to simulate market chaos
  * @version 0.1
  * @date 2024-01-12
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #include "brownian.hpp"
@@ -18,8 +18,10 @@ double
 BrownianMotion::generate_next_price()
 {
     double current_price = this->cur_value;
-    std::normal_distribution<double> distribution(-this->cur_value/1000, BROWNIAN_MOTION_DEVIATION);
-    
+    std::normal_distribution<double> distribution(
+        -this->cur_value / 1000, BROWNIAN_MOTION_DEVIATION
+    );
+
     double delta_current_price = distribution(this->random_number_generator);
     double new_price = current_price + delta_current_price;
 
@@ -27,5 +29,5 @@ BrownianMotion::generate_next_price()
     return new_price;
 }
 
-}
-}
+} // namespace brownian
+} // namespace nutc

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -19,15 +19,15 @@ namespace stochastic {
 double
 BrownianMotion::generate_next_price()
 {
-    double current_price = this->cur_value;
+    double current_price = cur_value_;
     std::normal_distribution<double> distribution(
-        -cur_value / 1000, BROWNIAN_MOTION_DEVIATION
+        -cur_value_ / 1000, BROWNIAN_MOTION_DEVIATION
     );
 
-    double delta_current_price = distribution(random_number_generator);
+    double delta_current_price = distribution(random_number_generator_);
     double new_price = current_price + delta_current_price;
 
-    cur_value = new_price;
+    cur_value_ = new_price;
     return new_price;
 }
 

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -9,19 +9,19 @@
  * 
  */
 
-#include "brownian.hpp";
+#include "brownian.hpp"
 
 namespace nutc {
 namespace brownian {
 
-float
+double
 BrownianMotion::generate_next_price()
 {
-    float current_price = this->cur_value;
-    std::normal_distribution<double> distribution(-this->cur_value/1000, stddev);
+    double current_price = this->cur_value;
+    std::normal_distribution<double> distribution(-this->cur_value/1000, BROWNIAN_MOTION_DEVIATION);
     
-    float delta_current_price = distribution(this->random_number_generator);
-    float new_price = current_price + delta_current_price;
+    double delta_current_price = distribution(this->random_number_generator);
+    double new_price = current_price + delta_current_price;
 
     this->cur_value = new_price;
     return new_price;

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -11,7 +11,7 @@
 
 #include "brownian.hpp"
 
-const double BROWNIAN_MOTION_DEVIATION = 0.4;
+constexpr double BROWNIAN_MOTION_DEVIATION = 0.4;
 
 namespace nutc {
 namespace stochastic {

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -1,0 +1,24 @@
+/**
+ * @file brownian.cpp
+ * @author Andrew Li (andrewli@u.northwestern.edu)
+ * @brief Brownian motion randomness to simulate market chaos
+ * @version 0.1
+ * @date 2024-01-12
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include "brownian.hpp";
+
+namespace nutc {
+namespace brownian {
+
+float
+BrownianMotion::generate_next_price()
+{
+
+}
+
+}
+}

--- a/exchange/src/randomness/brownian.cpp
+++ b/exchange/src/randomness/brownian.cpp
@@ -11,23 +11,25 @@
 
 #include "brownian.hpp"
 
+const double BROWNIAN_MOTION_DEVIATION = 0.4;
+
 namespace nutc {
-namespace brownian {
+namespace stochastic {
 
 double
 BrownianMotion::generate_next_price()
 {
     double current_price = this->cur_value;
     std::normal_distribution<double> distribution(
-        -this->cur_value / 1000, BROWNIAN_MOTION_DEVIATION
+        -cur_value / 1000, BROWNIAN_MOTION_DEVIATION
     );
 
-    double delta_current_price = distribution(this->random_number_generator);
+    double delta_current_price = distribution(random_number_generator);
     double new_price = current_price + delta_current_price;
 
-    this->cur_value = new_price;
+    cur_value = new_price;
     return new_price;
 }
 
-} // namespace brownian
+} // namespace stochastic
 } // namespace nutc

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -1,0 +1,53 @@
+/**
+ * @file brownian.hpp
+ * @author Andrew Li (andrewli@u.northwestern.edu)
+ * @brief Brownian motion randomness to simulate market chaos
+ * @version 0.1
+ * @date 2024-01-12
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace nutc {
+
+namespace brownian {
+
+class BrownianMotion {
+    std::vector<float> previous;
+    int seed;
+
+public:
+    // Constructor for BrownianMotion, takes a seed
+    BrownianMotion(const int seed) : seed(seed) {};
+
+    // Generates and returns the next price based on previous prices
+    float
+    generate_next_price();
+
+    // Force push a new price into the stack to affect
+    // the rng used to generate the next float
+    void
+    inject_price(
+        float new_price
+    )
+    {
+        this->previous.push_back(new_price);
+    }
+
+    // Force change the seed to something else
+    void
+    force_set_seed(
+        int new_seed
+    )
+    {
+        this->seed = new_seed;
+    }
+};
+
+} // namespace brownian
+} // namespace nutc

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -22,7 +22,7 @@ class BrownianMotion {
     std::mt19937 random_number_generator_;
 
 public:
-    // dConstructor for BrownianMotion, takes nothing
+    // Default constructor for BrownianMotion, takes nothing
     explicit BrownianMotion() : cur_value_(0)
     {
         std::random_device rd;
@@ -54,7 +54,7 @@ public:
 
     // Force set the seed to something else
     void
-    force_set_seed(unsigned int new_seed)
+    set_seed(unsigned int new_seed)
     {
         random_number_generator_ = std::mt19937(new_seed);
     }

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -18,30 +18,28 @@ namespace nutc {
 namespace stochastic {
 
 class BrownianMotion {
-    unsigned int seed;
-    double cur_value;
-
-    std::mt19937 random_number_generator;
+    double cur_value_;
+    std::mt19937 random_number_generator_;
 
 public:
     // dConstructor for BrownianMotion, takes nothing
-    explicit BrownianMotion() : cur_value(0)
+    explicit BrownianMotion() : cur_value_(0)
     {
         std::random_device rd;
-        random_number_generator = std::mt19937(rd());
+        random_number_generator_ = std::mt19937(rd());
     }
 
     // Constructor for BrownianMotion, takes a seed
-    explicit BrownianMotion(const unsigned int seed) : seed(seed), cur_value(0)
+    explicit BrownianMotion(const unsigned int seed) : cur_value_(0)
     {
-        random_number_generator = std::mt19937(seed);
+        random_number_generator_ = std::mt19937(seed);
     }
 
     // Constructor for BrownianMotion, takes a seed and initial value
     explicit BrownianMotion(const unsigned int seed, const double initial_value) :
-        seed(seed), cur_value(initial_value)
+        cur_value_(initial_value)
     {
-        random_number_generator = std::mt19937(seed);
+        random_number_generator_ = std::mt19937(seed);
     }
 
     // Generates and returns the next price based on previous prices
@@ -51,15 +49,14 @@ public:
     void
     set_price(double new_price)
     {
-        cur_value = new_price;
+        cur_value_ = new_price;
     }
 
     // Force set the seed to something else
     void
     force_set_seed(unsigned int new_seed)
     {
-        seed = new_seed;
-        random_number_generator = std::mt19937(new_seed);
+        random_number_generator_ = std::mt19937(new_seed);
     }
 };
 

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -21,28 +21,27 @@ namespace brownian {
 const double BROWNIAN_MOTION_DEVIATION = 0.4;
 
 class BrownianMotion {
-    int seed;
+    unsigned int seed;
     double cur_value;
-    double deviation;
 
     std::mt19937 random_number_generator;
 
 public:
     // dConstructor for BrownianMotion, takes nothing
-    BrownianMotion() : deviation(BROWNIAN_MOTION_DEVIATION) {
+    BrownianMotion() {
         std::random_device rd;
         random_number_generator = std::mt19937(rd());
-    };
+    }
 
     // Constructor for BrownianMotion, takes a seed
-    BrownianMotion(const int seed) : seed(seed), deviation(BROWNIAN_MOTION_DEVIATION) {
+    BrownianMotion(const unsigned int seed) : seed(seed) {
         random_number_generator = std::mt19937(seed);
-    };
+    }
 
     // Constructor for BrownianMotion, takes a seed and initial value
-    BrownianMotion(const int seed, const double initial_value) : seed(seed), cur_value(initial_value), deviation(BROWNIAN_MOTION_DEVIATION) {
+    BrownianMotion(const unsigned int seed, const double initial_value) : seed(seed), cur_value(initial_value) {
         random_number_generator = std::mt19937(seed);
-    };
+    }
 
     // Generates and returns the next price based on previous prices
     double
@@ -60,7 +59,7 @@ public:
     // Force set the seed to something else
     void
     force_set_seed(
-        int new_seed
+        unsigned int new_seed
     )
     {
         seed = new_seed;

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -12,13 +12,10 @@
 #pragma once
 
 #include <random>
-#include <vector>
 
 namespace nutc {
 
-namespace brownian {
-
-const double BROWNIAN_MOTION_DEVIATION = 0.4;
+namespace stochastic {
 
 class BrownianMotion {
     unsigned int seed;
@@ -28,31 +25,31 @@ class BrownianMotion {
 
 public:
     // dConstructor for BrownianMotion, takes nothing
-    BrownianMotion()
+    explicit BrownianMotion() : cur_value(0)
     {
         std::random_device rd;
         random_number_generator = std::mt19937(rd());
     }
 
     // Constructor for BrownianMotion, takes a seed
-    BrownianMotion(const unsigned int seed) : seed(seed)
+    explicit BrownianMotion(const unsigned int seed) : seed(seed), cur_value(0)
     {
         random_number_generator = std::mt19937(seed);
     }
 
     // Constructor for BrownianMotion, takes a seed and initial value
-    BrownianMotion(const unsigned int seed, const double initial_value) :
+    explicit BrownianMotion(const unsigned int seed, const double initial_value) :
         seed(seed), cur_value(initial_value)
     {
         random_number_generator = std::mt19937(seed);
     }
 
     // Generates and returns the next price based on previous prices
-    double generate_next_price();
+    [[nodiscard]] double generate_next_price();
 
     // Force set the current price
     void
-    inject_price(double new_price)
+    set_price(double new_price)
     {
         cur_value = new_price;
     }
@@ -62,8 +59,9 @@ public:
     force_set_seed(unsigned int new_seed)
     {
         seed = new_seed;
+        random_number_generator = std::mt19937(new_seed);
     }
 };
 
-} // namespace brownian
+} // namespace stochastic
 } // namespace nutc

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -4,9 +4,9 @@
  * @brief Brownian motion randomness to simulate market chaos
  * @version 0.1
  * @date 2024-01-12
- * 
+ *
  * @copyright Copyright (c) 2024
- * 
+ *
  */
 
 #pragma once
@@ -28,43 +28,41 @@ class BrownianMotion {
 
 public:
     // dConstructor for BrownianMotion, takes nothing
-    BrownianMotion() {
+    BrownianMotion()
+    {
         std::random_device rd;
         random_number_generator = std::mt19937(rd());
     }
 
     // Constructor for BrownianMotion, takes a seed
-    BrownianMotion(const unsigned int seed) : seed(seed) {
+    BrownianMotion(const unsigned int seed) : seed(seed)
+    {
         random_number_generator = std::mt19937(seed);
     }
 
     // Constructor for BrownianMotion, takes a seed and initial value
-    BrownianMotion(const unsigned int seed, const double initial_value) : seed(seed), cur_value(initial_value) {
+    BrownianMotion(const unsigned int seed, const double initial_value) :
+        seed(seed), cur_value(initial_value)
+    {
         random_number_generator = std::mt19937(seed);
     }
 
     // Generates and returns the next price based on previous prices
-    double
-    generate_next_price();
+    double generate_next_price();
 
     // Force set the current price
     void
-    inject_price(
-        double new_price
-    )
+    inject_price(double new_price)
     {
         cur_value = new_price;
     }
 
     // Force set the seed to something else
     void
-    force_set_seed(
-        unsigned int new_seed
-    )
+    force_set_seed(unsigned int new_seed)
     {
         seed = new_seed;
     }
-
 };
 
 } // namespace brownian

--- a/exchange/src/randomness/brownian.hpp
+++ b/exchange/src/randomness/brownian.hpp
@@ -11,42 +11,61 @@
 
 #pragma once
 
+#include <random>
 #include <vector>
 
 namespace nutc {
 
 namespace brownian {
 
+const double BROWNIAN_MOTION_DEVIATION = 0.4;
+
 class BrownianMotion {
-    std::vector<float> previous;
     int seed;
+    double cur_value;
+    double deviation;
+
+    std::mt19937 random_number_generator;
 
 public:
+    // dConstructor for BrownianMotion, takes nothing
+    BrownianMotion() : deviation(BROWNIAN_MOTION_DEVIATION) {
+        std::random_device rd;
+        random_number_generator = std::mt19937(rd());
+    };
+
     // Constructor for BrownianMotion, takes a seed
-    BrownianMotion(const int seed) : seed(seed) {};
+    BrownianMotion(const int seed) : seed(seed), deviation(BROWNIAN_MOTION_DEVIATION) {
+        random_number_generator = std::mt19937(seed);
+    };
+
+    // Constructor for BrownianMotion, takes a seed and initial value
+    BrownianMotion(const int seed, const double initial_value) : seed(seed), cur_value(initial_value), deviation(BROWNIAN_MOTION_DEVIATION) {
+        random_number_generator = std::mt19937(seed);
+    };
 
     // Generates and returns the next price based on previous prices
-    float
+    double
     generate_next_price();
 
-    // Force push a new price into the stack to affect
-    // the rng used to generate the next float
+    // Force set the current price
     void
     inject_price(
-        float new_price
+        double new_price
     )
     {
-        this->previous.push_back(new_price);
+        cur_value = new_price;
     }
 
-    // Force change the seed to something else
+    // Force set the seed to something else
     void
     force_set_seed(
         int new_seed
     )
     {
-        this->seed = new_seed;
+        seed = new_seed;
     }
+
 };
 
 } // namespace brownian


### PR DESCRIPTION
**What I did**
1. Implement Brownian motion random noise generator by using a modified skewed normal distribution
2. Let $L_n$ be the $n$-th generated point, then I define
$$L_{n+1} = L_n + N(L_n/1000, \mathrm{STDEV})$$
as the sequence representing the random noise. I add a normal distribution generated variable to the current term, but scale the mean to drag the price back towards equilibrium, like an ideal spring (it is indeed linear).

**What needs to be done**
1. Unit testing
2. Verifying that the math is reasonable, and picking better values than I picked (e.g. 0.4 for standard deviation)

**A figure**
![image](https://github.com/northwesternfintech/NUTC/assets/54134293/56d8b234-1763-4f9d-96a7-d4ed15180b52)
Red: unskewed normal distribution
Blue: skewed normal distribution
Note here that the price for the red does not get dragged back to equlibrium, and is a sum of $n$ normal distributions, which is itself a normal distribution.