### PR TITLE
Switch shared_ptr<trader> to reference

### DIFF
--- a/exchange/src/exchange/tickers/engine/order_storage.cpp
+++ b/exchange/src/exchange/tickers/engine/order_storage.cpp
@@ -3,18 +3,18 @@
 namespace nutc {
 namespace matching {
 stored_order::stored_order(
-    std::shared_ptr<traders::GenericTrader> trader, util::Side side, std::string ticker,
+    traders::GenericTrader& trader, util::Side side, std::string ticker,
     double quantity, double price, uint64_t tick
 ) :
-    trader(std::move(trader)), ticker(std::move(ticker)), side(side), price(price),
+    trader(trader), ticker(std::move(ticker)), side(side), price(price),
     quantity(quantity), tick(tick), order_index(get_and_increment_global_index())
 {}
 
 bool
 stored_order::operator==(const stored_order& other) const
 {
-    return trader->get_id() == other.trader->get_id() && ticker == other.ticker
-           && side == other.side && util::is_close_to_zero(price - other.price)
+    return &trader == &other.trader && ticker == other.ticker && side == other.side
+           && util::is_close_to_zero(price - other.price)
            && util::is_close_to_zero(quantity - other.quantity);
 }
 

--- a/exchange/src/exchange/tickers/engine/order_storage.hpp
+++ b/exchange/src/exchange/tickers/engine/order_storage.hpp
@@ -11,8 +11,8 @@ namespace nutc {
 namespace matching {
 
 struct stored_match {
-    std::shared_ptr<traders::GenericTrader> buyer;
-    std::shared_ptr<traders::GenericTrader> seller;
+    traders::GenericTrader& buyer;
+    traders::GenericTrader& seller;
     std::string ticker;
     util::Side side;
     decimal_price price;
@@ -20,17 +20,15 @@ struct stored_match {
 };
 
 struct stored_order {
-    std::shared_ptr<traders::GenericTrader> trader;
-    std::string ticker;
-    util::Side side;
-    decimal_price price;
-    double quantity;
-    uint64_t tick;
+    traders::GenericTrader& trader;
+    std::string ticker{};
+    util::Side side{};
+    decimal_price price{};
+    double quantity{};
+    uint64_t tick{};
 
     // Used to sort orders by time created
     uint64_t order_index;
-
-    stored_order() = default;
 
     operator messages::market_order() const { return {side, ticker, quantity, price}; }
 
@@ -42,12 +40,11 @@ struct stored_order {
     }
 
     stored_order(
-        std::shared_ptr<traders::GenericTrader> trader, util::Side side,
-        std::string ticker, double quantity, double price, uint64_t tick = 0
+        traders::GenericTrader& trader, util::Side side, std::string ticker,
+        double quantity, double price, uint64_t tick = 0
     );
 
     stored_order(const stored_order& other) = default;
-    stored_order& operator=(const stored_order& other) = default;
 
     bool operator==(const stored_order& other) const;
 

--- a/exchange/src/exchange/tickers/engine/orderbook.cpp
+++ b/exchange/src/exchange/tickers/engine/orderbook.cpp
@@ -33,7 +33,7 @@ stored_order
 OrderBook::remove_order(uint64_t order_id)
 {
     stored_order order = std::move(get_order_(order_id));
-    order.trader->process_order_remove(order);
+    order.trader.process_order_remove(order);
 
     order_index index{order.price, order_id};
     if (order.side == util::Side::buy) {
@@ -109,7 +109,7 @@ OrderBook::expire_orders(uint64_t tick)
 void
 OrderBook::add_order(stored_order order)
 {
-    order.trader->process_order_add(order);
+    order.trader.process_order_add(order);
 
     orders_by_tick_[order.tick].push_back(order.order_index);
     if (order.side == util::Side::buy) {

--- a/exchange/src/exchange/tickers/matching_cycle/base/base_strategy.cpp
+++ b/exchange/src/exchange/tickers/matching_cycle/base/base_strategy.cpp
@@ -15,11 +15,11 @@ std::vector<stored_order>
 BaseMatchingCycle::collect_orders(uint64_t new_tick)
 {
     std::vector<stored_order> orders;
-    for (const auto& trader : traders_) {
+    for (const std::shared_ptr<traders::GenericTrader>& trader : traders_) {
         auto incoming_orders = trader->read_orders();
         for (auto& order : incoming_orders) {
             orders.emplace_back(
-                trader, order.side, order.ticker, order.quantity, order.price, new_tick
+                *trader, order.side, order.ticker, order.quantity, order.price, new_tick
             );
         }
     }
@@ -58,9 +58,8 @@ BaseMatchingCycle::handle_matches_(std::vector<stored_match> matches)
     glz_matches.reserve(matches.size());
     for (auto& match : matches) {
         glz_matches.emplace_back(
-            match.ticker, match.side, match.price, match.quantity,
-            match.buyer->get_id(), match.seller->get_id(), match.buyer->get_capital(),
-            match.seller->get_capital()
+            match.ticker, match.side, match.price, match.quantity, match.buyer.get_id(),
+            match.seller.get_id(), match.buyer.get_capital(), match.seller.get_capital()
         );
     }
 

--- a/exchange/src/exchange/traders/trader_container.hpp
+++ b/exchange/src/exchange/traders/trader_container.hpp
@@ -7,7 +7,9 @@
 
 #include <cassert>
 
+#include <algorithm>
 #include <memory>
+#include <ranges>
 
 namespace nutc {
 namespace traders {
@@ -36,14 +38,18 @@ public:
     }
 
     void
-    remove_trader(std::shared_ptr<traders::GenericTrader> trader)
+    remove_trader(std::shared_ptr<traders::GenericTrader> to_remove)
     {
         lock_guard lock{trader_lock_};
-        std::erase_if(traders_, [&trader](auto& other) { return trader == other; });
+        for (auto& trader : traders_) {
+            if (trader == to_remove)
+                trader->disable();
+        }
     }
 
     size_t
     num_traders() const
+
     {
         lock_guard lock{trader_lock_};
         return traders_.size();

--- a/exchange/src/exchange/traders/trader_types/generic_trader.hpp
+++ b/exchange/src/exchange/traders/trader_types/generic_trader.hpp
@@ -23,11 +23,11 @@ public:
         USER_ID(std::move(user_id)), INITIAL_CAPITAL(capital)
     {}
 
+    virtual void
+    disable()
+    {}
+
     virtual ~GenericTrader() = default;
-    GenericTrader& operator=(GenericTrader&& other) = delete;
-    GenericTrader& operator=(const GenericTrader& other) = delete;
-    GenericTrader(GenericTrader&& other) = default;
-    GenericTrader(const GenericTrader& other) = delete;
 
     virtual bool
     can_leverage() const

--- a/exchange/test/src/unit/expiration/basic_expiration.cpp
+++ b/exchange/test/src/unit/expiration/basic_expiration.cpp
@@ -14,20 +14,22 @@ class UnitOrderExpiration : public ::testing::Test {
 
 protected:
     static constexpr const int DEFAULT_QUANTITY = 1000;
-    std::shared_ptr<nutc::traders::GenericTrader> trader1, trader2;
+
+    TraderContainer& manager_ =
+        nutc::traders::TraderContainer::get_instance(); // NOLINT(*)
+
+    nutc::traders::GenericTrader& trader1 =
+        *manager_.add_trader<TestTrader>(TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader2 =
+        *manager_.add_trader<TestTrader>(TEST_STARTING_CAPITAL);
 
     void
     SetUp() override
     {
-        trader1 = manager_.add_trader<TestTrader>(TEST_STARTING_CAPITAL);
-        trader2 = manager_.add_trader<TestTrader>(TEST_STARTING_CAPITAL);
-
-        trader1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
     }
 
-    TraderContainer& manager_ =
-        nutc::traders::TraderContainer::get_instance(); // NOLINT(*)
     nutc::matching::OrderBook orderbook_;
     Engine engine_;
 

--- a/exchange/test/src/unit/matching/basic_matching.cpp
+++ b/exchange/test/src/unit/matching/basic_matching.cpp
@@ -12,31 +12,29 @@ class UnitBasicMatching : public ::testing::Test {
 protected:
     using TestTrader = nutc::test_utils::TestTrader;
     static constexpr const int DEFAULT_QUANTITY = 1000;
-    std::shared_ptr<nutc::traders::GenericTrader> trader1, trader2, trader3;
+    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
+
+    nutc::traders::GenericTrader& trader1 =
+        *manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader2 =
+        *manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader3 =
+        *manager_.add_trader<TestTrader>(std::string("GHI"), TEST_STARTING_CAPITAL);
 
     void
     SetUp() override
     {
-        trader1 =
-            manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
-        trader2 =
-            manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
-        trader3 =
-            manager_.add_trader<TestTrader>(std::string("GHI"), TEST_STARTING_CAPITAL);
-
-        trader1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader3->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader3.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
     }
 
     void
     TearDown() override
     {
-        manager_.reset();
         SetUp();
     }
 
-    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
     nutc::matching::OrderBook orderbook_{};
     Engine engine_;
 

--- a/exchange/test/src/unit/matching/get_update.cpp
+++ b/exchange/test/src/unit/matching/get_update.cpp
@@ -18,24 +18,18 @@ using nutc::util::Side::sell;
 class UnitGetUpdate : public ::testing::Test {
 protected:
     using TestTrader = nutc::test_utils::TestTrader;
-    std::shared_ptr<nutc::traders::GenericTrader> trader1, trader2, trader3;
+    TraderContainer& manager_ =
+        nutc::traders::TraderContainer::get_instance(); // NOLINT(*)
+
+    nutc::traders::GenericTrader& trader1 =
+        *manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader2 =
+        *manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader3 =
+        *manager_.add_trader<TestTrader>(std::string("GHI"), TEST_STARTING_CAPITAL);
 
     std::shared_ptr<LevelUpdateGenerator> generator_ =
         std::make_shared<LevelUpdateGenerator>();
-
-    void
-    SetUp() override
-    {
-        trader1 =
-            manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
-        trader2 =
-            manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
-        trader3 =
-            manager_.add_trader<TestTrader>(std::string("GHI"), TEST_STARTING_CAPITAL);
-    }
-
-    TraderContainer& manager_ =
-        nutc::traders::TraderContainer::get_instance(); // NOLINT(*)
 
     OrderBook ob{generator_};
     // OrderBook after{};  // NOLINT (*)

--- a/exchange/test/src/unit/matching/invalid_orders.cpp
+++ b/exchange/test/src/unit/matching/invalid_orders.cpp
@@ -14,21 +14,19 @@ class UnitInvalidOrders : public ::testing::Test {
 protected:
     using TestTrader = nutc::test_utils::TestTrader;
     static constexpr const int DEFAULT_QUANTITY = 1000;
-    std::shared_ptr<nutc::traders::GenericTrader> trader1, trader2;
+    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
+    nutc::traders::GenericTrader& trader1 =
+        *manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader2 =
+        *manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
 
     void
     SetUp() override
     {
-        trader1 =
-            manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
-        trader2 =
-            manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
-
-        trader1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
     }
 
-    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
     nutc::matching::OrderBook orderbook_;
     Engine engine_;
 
@@ -41,7 +39,7 @@ protected:
 
 TEST_F(UnitInvalidOrders, RemoveThenAddFunds)
 {
-    trader1->modify_capital(-TEST_STARTING_CAPITAL);
+    trader1.modify_capital(-TEST_STARTING_CAPITAL);
 
     stored_order order2{trader2, sell, "ETHUSD", 1, 1, 0};
     stored_order order1{trader1, buy, "ETHUSD", 1, 1, 0};
@@ -54,7 +52,7 @@ TEST_F(UnitInvalidOrders, RemoveThenAddFunds)
     matches = add_to_engine_(order2);
     ASSERT_EQ(matches.size(), 0);
 
-    trader1->modify_capital(TEST_STARTING_CAPITAL);
+    trader1.modify_capital(TEST_STARTING_CAPITAL);
 
     // Kept, but not matched
     matches = add_to_engine_(order2);
@@ -68,7 +66,7 @@ TEST_F(UnitInvalidOrders, RemoveThenAddFunds)
 
 TEST_F(UnitInvalidOrders, MatchingInvalidFunds)
 {
-    trader1->modify_capital(-TEST_STARTING_CAPITAL);
+    trader1.modify_capital(-TEST_STARTING_CAPITAL);
 
     stored_order order1{trader1, buy, "ETHUSD", 1, 1, 0};
     stored_order order2{trader2, sell, "ETHUSD", 1, 1, 0};
@@ -84,15 +82,19 @@ TEST_F(UnitInvalidOrders, MatchingInvalidFunds)
 
 TEST_F(UnitInvalidOrders, SimpleManyInvalidOrder)
 {
-    auto t1 = manager_.add_trader<TestTrader>(std::string("A"), TEST_STARTING_CAPITAL);
-    auto t2 = manager_.add_trader<TestTrader>(std::string("B"), 0);
-    auto t3 = manager_.add_trader<TestTrader>(std::string("C"), TEST_STARTING_CAPITAL);
-    auto t4 = manager_.add_trader<TestTrader>(std::string("D"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& t1 =
+        *(manager_.add_trader<TestTrader>(std::string("A"), TEST_STARTING_CAPITAL));
+    nutc::traders::GenericTrader& t2 =
+        *(manager_.add_trader<TestTrader>(std::string("B"), 0));
+    nutc::traders::GenericTrader& t3 =
+        *(manager_.add_trader<TestTrader>(std::string("C"), TEST_STARTING_CAPITAL));
+    nutc::traders::GenericTrader& t4 =
+        *(manager_.add_trader<TestTrader>(std::string("D"), TEST_STARTING_CAPITAL));
 
-    t1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-    t2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-    t3->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-    t4->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    t1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    t2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    t3.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    t4.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
 
     stored_order order1{t1, buy, "ETHUSD", 1, 1, 0};
     stored_order order2{t2, buy, "ETHUSD", 1, 1, 0};

--- a/exchange/test/src/unit/matching/many_orders.cpp
+++ b/exchange/test/src/unit/matching/many_orders.cpp
@@ -12,27 +12,26 @@ class UnitManyOrders : public ::testing::Test {
 protected:
     using TestTrader = nutc::test_utils::TestTrader;
     static constexpr const int DEFAULT_QUANTITY = 1000;
-    std::shared_ptr<nutc::traders::GenericTrader> trader1, trader2, trader3, trader4;
+    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
+
+    nutc::traders::GenericTrader& trader1 =
+        *manager_.add_trader<TestTrader>(std::string("A"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader2 =
+        *manager_.add_trader<TestTrader>(std::string("B"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader3 =
+        *manager_.add_trader<TestTrader>(std::string("C"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader4 =
+        *manager_.add_trader<TestTrader>(std::string("D"), TEST_STARTING_CAPITAL);
 
     void
     SetUp() override
     {
-        trader1 =
-            manager_.add_trader<TestTrader>(std::string("A"), TEST_STARTING_CAPITAL);
-        trader2 =
-            manager_.add_trader<TestTrader>(std::string("B"), TEST_STARTING_CAPITAL);
-        trader3 =
-            manager_.add_trader<TestTrader>(std::string("C"), TEST_STARTING_CAPITAL);
-        trader4 =
-            manager_.add_trader<TestTrader>(std::string("D"), TEST_STARTING_CAPITAL);
-
-        trader1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader3->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader4->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader3.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader4.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
     }
 
-    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
     nutc::matching::OrderBook orderbook_;
     Engine engine_;
 

--- a/exchange/test/src/unit/matching/order_container.cpp
+++ b/exchange/test/src/unit/matching/order_container.cpp
@@ -15,21 +15,21 @@ class UnitOrderBookTest : public ::testing::Test {
 protected:
     using TestTrader = nutc::test_utils::TestTrader;
     static constexpr const int DEFAULT_QUANTITY = 1000;
-    std::shared_ptr<TestTrader> trader_1, trader_2;
+
+    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
+
+    nutc::traders::GenericTrader& trader_1 =
+        *manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader_2 =
+        *manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
 
     void
     SetUp() override
     {
-        trader_1 =
-            manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
-        trader_2 =
-            manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
-
-        trader_1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader_2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader_1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader_2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
     }
 
-    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
     nutc::matching::OrderBook container_;
 };
 

--- a/exchange/test/src/unit/matching/order_fee_matching.cpp
+++ b/exchange/test/src/unit/matching/order_fee_matching.cpp
@@ -13,31 +13,28 @@ class UnitOrderFeeMatching : public ::testing::Test {
 protected:
     using TestTrader = nutc::test_utils::TestTrader;
     static constexpr const int DEFAULT_QUANTITY = 1000;
-    std::shared_ptr<nutc::traders::GenericTrader> trader1, trader2, trader3;
+    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
+    nutc::traders::GenericTrader& trader1 =
+        *manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader2 =
+        *manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader3 =
+        *manager_.add_trader<TestTrader>(std::string("GHI"), TEST_STARTING_CAPITAL);
 
     void
     SetUp() override
     {
-        trader1 =
-            manager_.add_trader<TestTrader>(std::string("ABC"), TEST_STARTING_CAPITAL);
-        trader2 =
-            manager_.add_trader<TestTrader>(std::string("DEF"), TEST_STARTING_CAPITAL);
-        trader3 =
-            manager_.add_trader<TestTrader>(std::string("GHI"), TEST_STARTING_CAPITAL);
-
-        trader1->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader2->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-        trader3->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader1.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader2.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+        trader3.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
     }
 
     void
     TearDown() override
     {
-        manager_.reset();
         SetUp();
     }
 
-    TraderContainer& manager_ = nutc::traders::TraderContainer::get_instance();
     nutc::matching::OrderBook orderbook_;
     Engine engine_{.5};
 
@@ -59,8 +56,8 @@ TEST_F(UnitOrderFeeMatching, SimpleMatch)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "ABC", "DEF", sell, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), .5);
 }
 
 TEST_F(UnitOrderFeeMatching, MultipleMatches)
@@ -84,15 +81,15 @@ TEST_F(UnitOrderFeeMatching, MultipleMatches)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "ABC", "DEF", sell, 4, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -4 * 1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), 4 * .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -4 * 1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), 4 * .5);
 
     matches = add_to_engine_(sell1);
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "ABC", "DEF", sell, 3, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -4 * 1.5 + -3 * 1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), 4 * .5 + 3 * .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -4 * 1.5 + -3 * 1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), 4 * .5 + 3 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, NoMatchThenMatchBuy)
@@ -108,8 +105,8 @@ TEST_F(UnitOrderFeeMatching, NoMatchThenMatchBuy)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "DEF", "ABC", buy, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), .5);
-    ASSERT_EQ(trader2->get_capital_delta(), -1.5);
+    ASSERT_EQ(trader1.get_capital_delta(), .5);
+    ASSERT_EQ(trader2.get_capital_delta(), -1.5);
 }
 
 TEST_F(UnitOrderFeeMatching, NoMatchThenMatchSell)
@@ -129,9 +126,9 @@ TEST_F(UnitOrderFeeMatching, NoMatchThenMatchSell)
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "ABC", "GHI", sell, 1, 1);
     ASSERT_EQ_MATCH(matches[1], "ETHUSD", "DEF", "GHI", sell, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), -1.5);
-    ASSERT_EQ(trader3->get_capital_delta(), 1);
+    ASSERT_EQ(trader1.get_capital_delta(), -1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), -1.5);
+    ASSERT_EQ(trader3.get_capital_delta(), 1);
 }
 
 TEST_F(UnitOrderFeeMatching, PassivePriceMatchWithVolume)
@@ -145,8 +142,8 @@ TEST_F(UnitOrderFeeMatching, PassivePriceMatchWithVolume)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "ABC", "DEF", sell, 2, 2);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -2 * 2 * 1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), 2 * 2 * .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -2 * 2 * 1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), 2 * 2 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, PartialFill)
@@ -160,8 +157,8 @@ TEST_F(UnitOrderFeeMatching, PartialFill)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "ABC", "DEF", sell, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -1 * 1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), 1 * .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -1 * 1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), 1 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, MultipleFill)
@@ -180,8 +177,8 @@ TEST_F(UnitOrderFeeMatching, MultipleFill)
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "ABC", "DEF", sell, 1, 1);
     ASSERT_EQ_MATCH(matches.at(1), "ETHUSD", "ABC", "DEF", sell, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -2 * 1 * 1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), 2 * .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -2 * 1 * 1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), 2 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, MultiplePartialFill)
@@ -200,8 +197,8 @@ TEST_F(UnitOrderFeeMatching, MultiplePartialFill)
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "ABC", "DEF", sell, 1, 1);
     ASSERT_EQ_MATCH(matches.at(1), "ETHUSD", "ABC", "DEF", sell, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital_delta(), -2 * 1 * 1.5);
-    ASSERT_EQ(trader2->get_capital_delta(), 2 * .5);
+    ASSERT_EQ(trader1.get_capital_delta(), -2 * 1 * 1.5);
+    ASSERT_EQ(trader2.get_capital_delta(), 2 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, SimpleMatchReversed)
@@ -214,8 +211,8 @@ TEST_F(UnitOrderFeeMatching, SimpleMatchReversed)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "DEF", "ABC", buy, 1, 1);
 
-    ASSERT_EQ(trader2->get_capital_delta(), -1 * 1 * 1.5);
-    ASSERT_EQ(trader1->get_capital_delta(), 1 * .5);
+    ASSERT_EQ(trader2.get_capital_delta(), -1 * 1 * 1.5);
+    ASSERT_EQ(trader1.get_capital_delta(), 1 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, PassivePriceMatchReversed)
@@ -229,8 +226,8 @@ TEST_F(UnitOrderFeeMatching, PassivePriceMatchReversed)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ(matches.at(0).price, 1.0);
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "DEF", "ABC", buy, 1, 1);
-    ASSERT_EQ(trader2->get_capital_delta(), -1 * 1 * 1.5);
-    ASSERT_EQ(trader1->get_capital_delta(), 1 * .5);
+    ASSERT_EQ(trader2.get_capital_delta(), -1 * 1 * 1.5);
+    ASSERT_EQ(trader1.get_capital_delta(), 1 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, PartialFillReversed)
@@ -242,8 +239,8 @@ TEST_F(UnitOrderFeeMatching, PartialFillReversed)
     matches = add_to_engine_(order2);
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "DEF", "ABC", buy, 1, 1);
-    ASSERT_EQ(trader2->get_capital_delta(), -1 * 1 * 1.5);
-    ASSERT_EQ(trader1->get_capital_delta(), 1 * .5);
+    ASSERT_EQ(trader2.get_capital_delta(), -1 * 1 * 1.5);
+    ASSERT_EQ(trader1.get_capital_delta(), 1 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, MultipleFillReversed)
@@ -262,8 +259,8 @@ TEST_F(UnitOrderFeeMatching, MultipleFillReversed)
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "DEF", "ABC", buy, 1, 1);
     ASSERT_EQ_MATCH(matches.at(1), "ETHUSD", "DEF", "ABC", buy, 1, 1);
 
-    ASSERT_EQ(trader2->get_capital_delta(), -2 * 1 * 1.5);
-    ASSERT_EQ(trader1->get_capital_delta(), 2 * .5);
+    ASSERT_EQ(trader2.get_capital_delta(), -2 * 1 * 1.5);
+    ASSERT_EQ(trader1.get_capital_delta(), 2 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, MultiplePartialFillReversed)
@@ -282,13 +279,13 @@ TEST_F(UnitOrderFeeMatching, MultiplePartialFillReversed)
     ASSERT_EQ_MATCH(matches.at(0), "ETHUSD", "DEF", "ABC", buy, 1, 1);
     ASSERT_EQ_MATCH(matches.at(1), "ETHUSD", "DEF", "ABC", buy, 1, 1);
 
-    ASSERT_EQ(trader2->get_capital_delta(), -2 * 1 * 1.5);
-    ASSERT_EQ(trader1->get_capital_delta(), 2 * .5);
+    ASSERT_EQ(trader2.get_capital_delta(), -2 * 1 * 1.5);
+    ASSERT_EQ(trader1.get_capital_delta(), 2 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, NotEnoughToEnough)
 {
-    trader1->modify_capital(-TEST_STARTING_CAPITAL + 1);
+    trader1.modify_capital(-TEST_STARTING_CAPITAL + 1);
 
     stored_order order2{trader2, sell, "ETHUSD", 1, 1, 0};
     stored_order order1{trader1, buy, "ETHUSD", 1, 1, 0};
@@ -301,10 +298,10 @@ TEST_F(UnitOrderFeeMatching, NotEnoughToEnough)
     matches = add_to_engine_(order2);
     ASSERT_EQ(matches.size(), 0);
 
-    ASSERT_EQ(trader1->get_capital(), 1);
-    ASSERT_EQ(trader2->get_capital_delta(), 0);
+    ASSERT_EQ(trader1.get_capital(), 1);
+    ASSERT_EQ(trader2.get_capital_delta(), 0);
 
-    trader1->modify_capital(0.5);
+    trader1.modify_capital(0.5);
     ;
 
     // Kept, but not matched
@@ -316,13 +313,13 @@ TEST_F(UnitOrderFeeMatching, NotEnoughToEnough)
     ASSERT_EQ(matches.size(), 1);
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "ABC", "DEF", buy, 1, 1);
 
-    ASSERT_EQ(trader1->get_capital(), 0);
-    ASSERT_EQ(trader2->get_capital_delta(), 1 * .5);
+    ASSERT_EQ(trader1.get_capital(), 0);
+    ASSERT_EQ(trader2.get_capital_delta(), 1 * .5);
 }
 
 TEST_F(UnitOrderFeeMatching, MatchingInvalidFunds)
 {
-    trader1->modify_capital(-TEST_STARTING_CAPITAL + 1);
+    trader1.modify_capital(-TEST_STARTING_CAPITAL + 1);
 
     stored_order order1{trader1, buy, "ETHUSD", 1, 1, 0};
     stored_order order2{trader2, sell, "ETHUSD", 1, 1, 0};
@@ -335,22 +332,25 @@ TEST_F(UnitOrderFeeMatching, MatchingInvalidFunds)
     matches = add_to_engine_(order2);
     ASSERT_EQ(matches.size(), 0);
 
-    ASSERT_EQ(trader1->get_capital(), 1);
-    ASSERT_EQ(trader2->get_capital_delta(), 0);
+    ASSERT_EQ(trader1.get_capital(), 1);
+    ASSERT_EQ(trader2.get_capital_delta(), 0);
 }
 
 TEST_F(UnitOrderFeeMatching, SimpleManyInvalidOrder)
 {
-    std::shared_ptr<nutc::traders::GenericTrader> trader4, trader5, trader6, trader7;
-    trader4 = manager_.add_trader<TestTrader>(std::string("A"), TEST_STARTING_CAPITAL);
-    trader5 = manager_.add_trader<TestTrader>(std::string("B"), 1);
-    trader6 = manager_.add_trader<TestTrader>(std::string("C"), TEST_STARTING_CAPITAL);
-    trader7 = manager_.add_trader<TestTrader>(std::string("D"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader4 =
+        *manager_.add_trader<TestTrader>(std::string("A"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader5 =
+        *manager_.add_trader<TestTrader>(std::string("B"), 1);
+    nutc::traders::GenericTrader& trader6 =
+        *manager_.add_trader<TestTrader>(std::string("C"), TEST_STARTING_CAPITAL);
+    nutc::traders::GenericTrader& trader7 =
+        *manager_.add_trader<TestTrader>(std::string("D"), TEST_STARTING_CAPITAL);
 
-    trader4->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-    trader5->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-    trader6->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
-    trader7->modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    trader4.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    trader5.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    trader6.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
+    trader7.modify_holdings("ETHUSD", DEFAULT_QUANTITY);
 
     stored_order order1{trader4, buy, "ETHUSD", 1, 1, 0};
     stored_order order2{trader5, buy, "ETHUSD", 1, 1, 0};
@@ -371,8 +371,8 @@ TEST_F(UnitOrderFeeMatching, SimpleManyInvalidOrder)
     ASSERT_EQ_MATCH(matches[0], "ETHUSD", "A", "D", sell, 1, 1);
     ASSERT_EQ_MATCH(matches[1], "ETHUSD", "C", "D", sell, 1, 1);
 
-    ASSERT_EQ(trader4->get_capital_delta(), -1.5);
-    ASSERT_EQ(trader5->get_capital_delta(), 0);
-    ASSERT_EQ(trader6->get_capital_delta(), -1 * 1 * 1.5);
-    ASSERT_EQ(trader7->get_capital_delta(), 2 * .5);
+    ASSERT_EQ(trader4.get_capital_delta(), -1.5);
+    ASSERT_EQ(trader5.get_capital_delta(), 0);
+    ASSERT_EQ(trader6.get_capital_delta(), -1 * 1 * 1.5);
+    ASSERT_EQ(trader7.get_capital_delta(), 2 * .5);
 }

--- a/exchange/test/src/util/helpers/test_cycle.hpp
+++ b/exchange/test/src/util/helpers/test_cycle.hpp
@@ -13,7 +13,7 @@ namespace test {
 
 class TestMatchingCycle : public matching::BaseMatchingCycle {
 public:
-    matching::stored_order last_order;
+    std::unique_ptr<matching::stored_order> last_order;
 
     TestMatchingCycle(
         std::vector<std::string> ticker_names,

--- a/exchange/test/src/util/macros.cpp
+++ b/exchange/test/src/util/macros.cpp
@@ -36,8 +36,8 @@ validate_match(
     double price, double quantity
 )
 {
-    return match.ticker == ticker && match.buyer->get_id() == buyer_id
-           && match.seller->get_id() == seller_id && match.side == side
+    return match.ticker == ticker && match.buyer.get_id() == buyer_id
+           && match.seller.get_id() == seller_id && match.side == side
            && is_nearly_equal(match.price, price)
            && is_nearly_equal(match.quantity, quantity);
 }

--- a/exchange/test/src/util/macros.hpp
+++ b/exchange/test/src/util/macros.hpp
@@ -56,8 +56,8 @@ bool validate_market_order(
             << ", side = " << static_cast<int>(side_) << ", price = " << (price_)      \
             << ", quantity = " << (quantity_)                                          \
             << ". Actual match: ticker = " << (match).ticker                           \
-            << ", buyer_id = " << (match).buyer->get_id()                              \
-            << ", seller_id = " << (match).seller->get_id()                            \
+            << ", buyer_id = " << (match).buyer.get_id()                               \
+            << ", seller_id = " << (match).seller.get_id()                             \
             << ", side = " << static_cast<int>((match).side)                           \
             << ", price = " << (match).price << ", quantity = " << (match).quantity;   \
     } while (0)


### PR DESCRIPTION
Making a shared ptr of a trader for every single order is super expensive. We know the lifetime in (almost) all cases so just use a reference

Also, remove_trader now just disables a trader to guarantee lifetimes