### PR TITLE
Remove unnecessary dependency from generic_trader

### DIFF
--- a/exchange/src/exchange/traders/trader_types/generic_trader.hpp
+++ b/exchange/src/exchange/traders/trader_types/generic_trader.hpp
@@ -2,11 +2,9 @@
 
 #include "common/types/decimal.hpp"
 #include "common/types/messages/messages_wrapper_to_exchange.hpp"
-#include "common/types/position.hpp"
 #include "exchange/traders/portfolio/trader_portfolio.hpp"
 
 #include <absl/hash/hash.h>
-#include <boost/process.hpp>
 
 #include <string>
 


### PR DESCRIPTION
Removed boost/process. This header is included by most translation units in the exchange so this reduces compilation time by 25% lol.

I did profile this but too lazy to post ss